### PR TITLE
updated dockerfile to create a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,31 @@
-FROM python:3.8-slim
+# ================================================================================================
+# === Stage 1: Setup the Data Science Environment with JupyterHub ===============================
+# ================================================================================================
+FROM python:3.8-slim as python-build
 
 # Set a working directory
 WORKDIR /usr/src/app
 
 # Install necessary libraries
-RUN pip install --no-cache-dir numpy pandas matplotlib scikit-learn tensorflow keras jupyter
+RUN pip install --no-cache-dir numpy pandas matplotlib scikit-learn tensorflow keras jupyter jupyterhub
+
+# ================================================================================================
+# === Stage 2: Additional Setup (if needed) ======================================================
+# ================================================================================================
+# Use a base image like alpine if you need to run additional light-weight services or configurations
+# FROM alpine:latest as final-setup
+# WORKDIR /app
+
+# COPY --from=python-build /usr/src/app /app
+
+# ================================================================================================
+# === Final Stage: Bundle everything in the runtime image =========================================
+# ================================================================================================
+FROM python:3.8-slim
+WORKDIR /usr/src/app
+
+# Copy everything from the first stage
+COPY --from=python-build /usr/src/app .
 
 # Expose the port Jupyter Notebook will run on
 EXPOSE 8888


### PR DESCRIPTION
For our JupyterHub environment, I created a multi-stage build that first sets up the Python environment with JupyterHub and its dependencies, and then, if necessary, adds any additional services or configurations.

The setup for JupyterHub in our first Dockerfile is quite straightforward and might not need a multi-stage build unless we're adding more complexity.

This is a an updated version of our Dockerfile, assuming we might want to include some additional setup or configuration in a later stage.