### PR TITLE
adds IAM policy with terraform

### DIFF
--- a/tf/config.hcl
+++ b/tf/config.hcl
@@ -1,0 +1,37 @@
+provider "google" {
+  # Provider configuration
+  credentials = file("<PATH_TO_YOUR_SERVICE_ACCOUNT_KEY.json>")
+  project     = "<YOUR_PROJECT_ID>"
+  region      = "<YOUR_REGION>"
+}
+
+resource "google_project_iam_custom_role" "data_scientist_role" {
+  role_id     = "dataScientistRole"
+  title       = "Data Scientist Role"
+  description = "A custom role for data scientists"
+  permissions = [
+    "bigquery.datasets.get",
+    "bigquery.jobs.create",
+    "bigquery.tables.get",
+    "bigquery.tables.list",
+    "storage.objects.get",
+    "storage.objects.list",
+    # Add other necessary permissions
+  ]
+}
+
+resource "google_project_iam_policy" "data_scientist_policy" {
+  project     = "<YOUR_PROJECT_ID>"
+  policy_data = data.google_iam_policy.data_scientist_policy.policy_data
+}
+
+data "google_iam_policy" "data_scientist_policy" {
+  binding {
+    role = google_project_iam_custom_role.data_scientist_role.id
+
+    members = [
+      "user:example-user@example.com",
+      # Add other members who should assume this role
+    ]
+  }
+}


### PR DESCRIPTION
This adds Terraform Configuration for GCP IAM: this example demonstrates creating a custom IAM role for data scientists and attaching a policy to it for accessing specific GCP resources, like BigQuery and Cloud Storage.